### PR TITLE
Implement overlap calculation engine

### DIFF
--- a/lib/creature_crossing/overlap.ex
+++ b/lib/creature_crossing/overlap.ex
@@ -1,0 +1,217 @@
+defmodule CreatureCrossing.Overlap do
+  @moduledoc """
+  Core overlap calculation engine for Creature Crossing.
+
+  Given a list of selected critters and a hemisphere, finds the single best
+  month + time window where the most critters are simultaneously catchable.
+  """
+
+  @month_names %{
+    1 => "January", 2 => "February", 3 => "March", 4 => "April",
+    5 => "May", 6 => "June", 7 => "July", 8 => "August",
+    9 => "September", 10 => "October", 11 => "November", 12 => "December"
+  }
+
+  @doc """
+  Calculates the best overlap for the given critters and hemisphere.
+
+  Returns a map with:
+    - `:month` — the best month name (e.g. "June"), or nil
+    - `:time_range` — formatted time string (e.g. "1:00 PM - 3:00 PM"), or "No Overlap"
+    - `:critter_count` — number of critters catchable in that window
+    - `:critters` — list of critter maps available in that window
+  """
+  def calculate(critters, hemisphere) when hemisphere in ["north", "south"] do
+    hemi_key = hemisphere
+
+    # For each month 1-12, find which critters are available and their hours
+    results =
+      for month <- 1..12 do
+        available =
+          Enum.filter(critters, fn critter ->
+            months = get_in(critter, [hemi_key, "months_array"]) || []
+            month in months
+          end)
+
+        if available == [] do
+          {month, 0, [], []}
+        else
+          # Build a set of available hours for each critter in this month
+          hour_sets =
+            Enum.map(available, fn critter ->
+              time_str =
+                get_in(critter, [hemi_key, "times_by_month", to_string(month)]) || "All day"
+
+              {critter, parse_time_ranges(time_str)}
+            end)
+
+          # Count critters available at each hour (0-23)
+          hour_counts =
+            for hour <- 0..23 do
+              matching =
+                Enum.filter(hour_sets, fn {_critter, hours} ->
+                  MapSet.member?(hours, hour)
+                end)
+
+              {hour, length(matching), Enum.map(matching, &elem(&1, 0))}
+            end
+
+          # Find the max overlap count
+          max_count = hour_counts |> Enum.map(&elem(&1, 1)) |> Enum.max()
+
+          # Get the consecutive range(s) with max overlap
+          best_hours =
+            hour_counts
+            |> Enum.filter(fn {_h, count, _} -> count == max_count end)
+            |> Enum.map(&elem(&1, 0))
+
+          # Get critters from the first best hour
+          {_, _, best_critters} =
+            Enum.find(hour_counts, fn {h, _, _} -> h == hd(best_hours) end)
+
+          {month, max_count, best_hours, best_critters}
+        end
+      end
+
+    # Find the month with the highest overlap
+    {best_month, best_count, best_hours, best_critters} =
+      Enum.max_by(results, &elem(&1, 1))
+
+    if best_count == 0 do
+      %{
+        month: nil,
+        time_range: "No Overlap",
+        critter_count: 0,
+        critters: []
+      }
+    else
+      %{
+        month: @month_names[best_month],
+        time_range: format_time_range(best_hours),
+        critter_count: best_count,
+        critters: best_critters
+      }
+    end
+  end
+
+  @doc """
+  Parses a Nookipedia time string into a MapSet of hours (0-23).
+
+  Handles:
+    - "All day" → all 24 hours
+    - "4 AM – 7 PM" → hours 4..18
+    - "9 PM – 4 AM" → hours 21..23, 0..3 (midnight wrap)
+    - "9 AM – 4 PM; 9 PM – 4 AM" → union of both ranges
+  """
+  def parse_time_ranges("All day"), do: MapSet.new(0..23)
+
+  def parse_time_ranges(time_str) do
+    time_str
+    |> String.split(~r/[;&]/)
+    |> Enum.map(&String.trim/1)
+    |> Enum.flat_map(&parse_single_range/1)
+    |> MapSet.new()
+  end
+
+  defp parse_single_range(range_str) do
+    case String.split(range_str, ~r/\s*[\x{2013}\x{2014}\-]+\s*/u) do
+      [start_str, end_str] ->
+        start_hour = parse_hour(start_str)
+        end_hour = parse_hour(end_str)
+
+        if start_hour <= end_hour do
+          # Normal range: 4 AM (4) to 7 PM (19) → 4..18
+          Enum.to_list(start_hour..(end_hour - 1))
+        else
+          # Midnight wrap: 9 PM (21) to 4 AM (4) → 21..23, 0..3
+          Enum.to_list(start_hour..23) ++ Enum.to_list(0..(end_hour - 1))
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  @doc """
+  Parses an hour string like "4 AM", "9 PM", "12 AM", "12 PM" into 0-23.
+  """
+  def parse_hour(str) do
+    str = String.trim(str)
+
+    case Regex.run(~r/(\d+)\s*(AM|PM|am|pm)/i, str) do
+      [_, hour_str, period] ->
+        hour = String.to_integer(hour_str)
+        period = String.upcase(period)
+
+        cond do
+          period == "AM" and hour == 12 -> 0
+          period == "PM" and hour == 12 -> 12
+          period == "PM" -> hour + 12
+          true -> hour
+        end
+
+      _ ->
+        0
+    end
+  end
+
+  @doc """
+  Formats a list of hours into a human-readable time range.
+
+  Groups consecutive hours and returns the longest consecutive run
+  as "X:00 AM/PM - Y:00 AM/PM".
+  """
+  def format_time_range(hours) do
+    chunks =
+      hours
+      |> Enum.sort()
+      |> chunk_consecutive()
+
+    chunk = Enum.max_by(chunks, &length/1)
+    start_hour = hd(chunk)
+    end_hour = rem(List.last(chunk) + 1, 24)
+    "#{format_hour(start_hour)} - #{format_hour(end_hour)}"
+  end
+
+  defp chunk_consecutive([]), do: [[]]
+
+  defp chunk_consecutive([first | rest]) do
+    chunks =
+      Enum.reduce(rest, [[first]], fn hour, [current | groups] ->
+        if hour == List.last(current) + 1 do
+          [current ++ [hour] | groups]
+        else
+          [[hour] | [current | groups]]
+        end
+      end)
+      |> Enum.reverse()
+
+    # Join first and last chunks if they wrap around midnight (23 → 0)
+    case chunks do
+      [first_chunk | middle] when length(chunks) > 1 ->
+        last_chunk = List.last(middle)
+        rest_middle = Enum.drop(middle, -1)
+
+        if List.last(last_chunk) == 23 and hd(first_chunk) == 0 do
+          merged = last_chunk ++ first_chunk
+          [merged | rest_middle]
+        else
+          chunks
+        end
+
+      _ ->
+        chunks
+    end
+  end
+
+  defp format_hour(0), do: "12:00 AM"
+  defp format_hour(12), do: "12:00 PM"
+
+  defp format_hour(hour) when hour < 12 do
+    "#{hour}:00 AM"
+  end
+
+  defp format_hour(hour) do
+    "#{hour - 12}:00 PM"
+  end
+end

--- a/lib/creature_crossing_web/live/creature_crossing_live.ex
+++ b/lib/creature_crossing_web/live/creature_crossing_live.ex
@@ -27,7 +27,8 @@ defmodule CreatureCrossingWeb.CreatureCrossingLive do
        sea: sea,
        selected: MapSet.new(),
        hemisphere: "north",
-       mode: "missing"
+       mode: "missing",
+       result: nil
      )}
   end
 
@@ -57,8 +58,17 @@ defmodule CreatureCrossingWeb.CreatureCrossingLive do
 
   @impl true
   def handle_event("calculate", _params, socket) do
-    # Will be implemented in 2-2
-    {:noreply, socket}
+    %{selected: selected, bugs: bugs, fish: fish, sea: sea, hemisphere: hemisphere} =
+      socket.assigns
+
+    all_critters = bugs ++ fish ++ sea
+
+    selected_critters =
+      Enum.filter(all_critters, fn c -> MapSet.member?(selected, c["name"]) end)
+
+    result = CreatureCrossing.Overlap.calculate(selected_critters, hemisphere)
+
+    {:noreply, assign(socket, result: result)}
   end
 
   @impl true

--- a/test/creature_crossing/overlap_test.exs
+++ b/test/creature_crossing/overlap_test.exs
@@ -1,0 +1,189 @@
+defmodule CreatureCrossing.OverlapTest do
+  use ExUnit.Case, async: true
+
+  alias CreatureCrossing.Overlap
+
+  describe "parse_hour/1" do
+    test "parses AM hours" do
+      assert Overlap.parse_hour("4 AM") == 4
+      assert Overlap.parse_hour("9 AM") == 9
+      assert Overlap.parse_hour("11 AM") == 11
+    end
+
+    test "parses PM hours" do
+      assert Overlap.parse_hour("1 PM") == 13
+      assert Overlap.parse_hour("7 PM") == 19
+      assert Overlap.parse_hour("11 PM") == 23
+    end
+
+    test "handles 12 AM (midnight) and 12 PM (noon)" do
+      assert Overlap.parse_hour("12 AM") == 0
+      assert Overlap.parse_hour("12 PM") == 12
+    end
+  end
+
+  describe "parse_time_ranges/1" do
+    test "parses 'All day' to all 24 hours" do
+      result = Overlap.parse_time_ranges("All day")
+      assert MapSet.size(result) == 24
+      assert MapSet.member?(result, 0)
+      assert MapSet.member?(result, 23)
+    end
+
+    test "parses normal daytime range" do
+      result = Overlap.parse_time_ranges("4 AM – 7 PM")
+      # 4 AM to 7 PM = hours 4..18 (15 hours)
+      assert MapSet.size(result) == 15
+      assert MapSet.member?(result, 4)
+      assert MapSet.member?(result, 18)
+      refute MapSet.member?(result, 19)
+      refute MapSet.member?(result, 3)
+    end
+
+    test "parses midnight-wrapping range" do
+      result = Overlap.parse_time_ranges("9 PM – 4 AM")
+      # 9 PM to 4 AM = hours 21, 22, 23, 0, 1, 2, 3 (7 hours)
+      assert MapSet.size(result) == 7
+      assert MapSet.member?(result, 21)
+      assert MapSet.member?(result, 23)
+      assert MapSet.member?(result, 0)
+      assert MapSet.member?(result, 3)
+      refute MapSet.member?(result, 4)
+      refute MapSet.member?(result, 20)
+    end
+
+    test "parses multi-window ranges separated by semicolon" do
+      result = Overlap.parse_time_ranges("9 AM – 4 PM; 9 PM – 4 AM")
+      # 9 AM–4 PM = 9..15 (7 hours) + 9 PM–4 AM = 21..23, 0..3 (7 hours) = 14 total
+      assert MapSet.size(result) == 14
+      assert MapSet.member?(result, 9)
+      assert MapSet.member?(result, 15)
+      assert MapSet.member?(result, 21)
+      assert MapSet.member?(result, 0)
+    end
+  end
+
+  describe "format_time_range/1" do
+    test "formats a single hour" do
+      assert Overlap.format_time_range([14]) == "2:00 PM - 3:00 PM"
+    end
+
+    test "formats consecutive hours" do
+      assert Overlap.format_time_range([13, 14, 15]) == "1:00 PM - 4:00 PM"
+    end
+
+    test "formats midnight-area hours" do
+      assert Overlap.format_time_range([0]) == "12:00 AM - 1:00 AM"
+    end
+
+    test "formats noon" do
+      assert Overlap.format_time_range([12]) == "12:00 PM - 1:00 PM"
+    end
+
+    test "picks longest consecutive run when hours are non-consecutive" do
+      # Two runs: [2,3,4] (length 3) and [20,21] (length 2) → picks 2-5
+      assert Overlap.format_time_range([2, 3, 4, 20, 21]) == "2:00 AM - 5:00 AM"
+    end
+  end
+
+  describe "calculate/2" do
+    test "finds the best overlap month and time" do
+      # Two critters available in January, 4 AM – 7 PM
+      critters = [
+        critter("Bug A", [1, 2, 3], "4 AM – 7 PM"),
+        critter("Bug B", [1, 2], "9 AM – 5 PM")
+      ]
+
+      result = Overlap.calculate(critters, "north")
+      assert result.month == "January"
+      assert result.critter_count == 2
+      assert length(result.critters) == 2
+      # Overlap is 9 AM – 5 PM (both available)
+      assert result.time_range == "9:00 AM - 5:00 PM"
+    end
+
+    test "handles critters with midnight-wrapping times" do
+      critters = [
+        critter("Night Bug", [6], "9 PM – 4 AM"),
+        critter("All Day Bug", [6], "All day")
+      ]
+
+      result = Overlap.calculate(critters, "north")
+      assert result.month == "June"
+      assert result.critter_count == 2
+      # Both overlap during 9 PM – 4 AM
+      assert result.time_range == "9:00 PM - 4:00 AM"
+    end
+
+    test "handles 'All day' critters" do
+      critters = [
+        critter("All Day A", [3], "All day"),
+        critter("All Day B", [3], "All day")
+      ]
+
+      result = Overlap.calculate(critters, "north")
+      assert result.month == "March"
+      assert result.critter_count == 2
+    end
+
+    test "returns no overlap when no critters provided" do
+      result = Overlap.calculate([], "north")
+      assert result.month == nil
+      assert result.time_range == "No Overlap"
+      assert result.critter_count == 0
+      assert result.critters == []
+    end
+
+    test "uses south hemisphere data when specified" do
+      critters = [
+        %{
+          "name" => "Southern Bug",
+          "image_url" => "img.png",
+          "north" => %{
+            "months_array" => [],
+            "times_by_month" => %{}
+          },
+          "south" => %{
+            "months_array" => [7],
+            "times_by_month" => %{"7" => "All day"}
+          }
+        }
+      ]
+
+      result = Overlap.calculate(critters, "south")
+      assert result.month == "July"
+      assert result.critter_count == 1
+    end
+
+    test "picks month with highest overlap count" do
+      critters = [
+        critter("Bug A", [1, 6], "All day"),
+        critter("Bug B", [6], "All day"),
+        critter("Bug C", [6], "All day")
+      ]
+
+      result = Overlap.calculate(critters, "north")
+      # June has 3 critters, January only 1
+      assert result.month == "June"
+      assert result.critter_count == 3
+    end
+  end
+
+  # Helper to build a critter map with north hemisphere data
+  defp critter(name, months, time) do
+    %{
+      "name" => name,
+      "image_url" => "https://example.com/#{name}.png",
+      "location" => "Flying",
+      "rarity" => "Common",
+      "north" => %{
+        "months_array" => months,
+        "times_by_month" => Map.new(months, fn m -> {to_string(m), time} end)
+      },
+      "south" => %{
+        "months_array" => [],
+        "times_by_month" => %{}
+      }
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- New `CreatureCrossing.Overlap` module with core algorithm: finds the best month + time window where the most selected critters are simultaneously catchable
- Parses Nookipedia time strings: "All day", normal ranges ("4 AM – 7 PM"), midnight-wrapping ("9 PM – 4 AM"), and multi-window ("9 AM – 4 PM; 9 PM – 4 AM")
- Handles midnight-wrapping consecutive hour detection for accurate range formatting
- Uses correct hemisphere data based on user's toggle
- Wired into LiveView: Calculate button now runs the engine and stores result in assigns

## Test plan
- [x] 18 unit tests for overlap engine (parse_hour, parse_time_ranges, format_time_range, calculate with various scenarios including midnight wrap, All day, no overlap, hemisphere switching)
- [x] Full suite passes (46 tests, 0 failures)
- [ ] Manual testing: select 5+ critters, click Calculate, verify result stored (display coming in 2-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)