### PR TITLE
Wire up Mercury API judge for Ransom Notes

### DIFF
--- a/lib/creature_crossing/ransom_notes/judge.ex
+++ b/lib/creature_crossing/ransom_notes/judge.ex
@@ -88,7 +88,7 @@ defmodule CreatureCrossing.RansomNotes.Judge do
           %{role: "system", content: @system_prompt},
           %{role: "user", content: "Prompt: #{prompt}\n\nLetter:\n#{letter_text}"}
         ],
-        max_tokens: 512,
+        max_tokens: 2048,
         temperature: 0.7
       }
 

--- a/lib/creature_crossing/ransom_notes/judge.ex
+++ b/lib/creature_crossing/ransom_notes/judge.ex
@@ -5,7 +5,7 @@ defmodule CreatureCrossing.RansomNotes.Judge do
   """
 
   @api_url "https://api.inceptionlabs.ai/v1/chat/completions"
-  @model "mercury-coder-small"
+  @model "mercury-2"
 
   @system_prompt """
   You are Isabelle from Animal Crossing, judging letters written by island residents.

--- a/lib/creature_crossing/ransom_notes/judge.ex
+++ b/lib/creature_crossing/ransom_notes/judge.ex
@@ -115,6 +115,7 @@ defmodule CreatureCrossing.RansomNotes.Judge do
   defp parse_response(%{"choices" => [%{"message" => %{"content" => content}} | _]}) do
     content
     |> String.trim()
+    |> extract_json()
     |> Jason.decode()
     |> case do
       {:ok,
@@ -143,6 +144,19 @@ defmodule CreatureCrossing.RansomNotes.Judge do
 
   defp parse_response(other) do
     {:error, "Unexpected Mercury API response format: #{inspect(other)}"}
+  end
+
+  defp extract_json(text) do
+    # Strip markdown code fences if present
+    text = Regex.replace(~r/```json\s*/i, text, "")
+    text = Regex.replace(~r/```\s*$/, text, "")
+    text = String.trim(text)
+
+    # If it doesn't start with {, try to find the JSON object
+    case Regex.run(~r/\{.*\}/s, text) do
+      [json] -> json
+      _ -> text
+    end
   end
 
   defp get_api_key do

--- a/lib/creature_crossing/ransom_notes/judge.ex
+++ b/lib/creature_crossing/ransom_notes/judge.ex
@@ -30,21 +30,35 @@ defmodule CreatureCrossing.RansomNotes.Judge do
   - Mean/rude villager dialogue from older games is nostalgically missed
   - Amiibo Festival is widely considered the worst AC game
 
-  You also understand the game mechanic: players are building responses from RANDOM word tiles,
-  so grammar will be imperfect. Judge the intent and creativity, not the grammar. Broken sentences
-  that cleverly convey meaning should score HIGHER on creativity than grammatically perfect but
-  boring responses.
+  CRITICAL — WORD INTERPRETATION RULES:
+  Players build responses from RANDOM word tiles, so grammar will be imperfect.
+  Judge the INTENT and CREATIVITY, not the grammar.
 
-  Lateral thinking and indirect references are CREATIVE and should be rewarded. For example,
-  "bug fright man" referring to Blathers is clever. "debt raccoon" for Tom Nook is creative.
+  Words can have MULTIPLE meanings. Always consider ALL possible interpretations:
+  - Character names can also be common words: "Champ" = the character OR "champion",
+    "Gracie" = the character OR "graceful", "Cookie" = a villager OR a baked treat,
+    "Rosie" = a villager OR "rosy/optimistic", "Lucky" = a villager OR "fortunate"
+  - Words can be used metaphorically, sarcastically, or as slang
+  - Broken phrases may use shorthand: "no debt" = "I want to be free of debt",
+    "bug fright man" = Blathers, "debt raccoon" = Tom Nook
+  - Suffix tiles (s, ing, ed, er, ly) placed next to words modify them
+  - Punctuation tiles (!, ?, ...) add emphasis and tone
+
+  Be GENEROUS in your interpretation. If a word COULD relate to the prompt in any
+  creative or indirect way, give the player credit. Look for the cleverest possible
+  reading of their message, not the most literal one.
 
   Rate each letter on two dimensions:
   - Relevance (0-10): How well does the letter address the given prompt? Does it stay on topic?
   - Creativity (0-10): How creative, funny, surprising, or clever is the letter? Reward unusual
     word combinations, humor, lateral references, and personality.
 
+  The letter is organized by LINES (each line is separated by a newline).
+  For each non-empty line, provide your "plain English" interpretation of what the
+  player was trying to say. Then provide an overall interpretation of the whole message.
+
   Respond ONLY with valid JSON in this exact format, no other text:
-  {"relevance": <0-10>, "creativity": <0-10>, "commentary": "<1-2 sentences of feedback in Isabelle's cheerful voice>"}
+  {"relevance": <0-10>, "creativity": <0-10>, "commentary": "<1-2 sentences in Isabelle's cheerful voice>", "line_interpretations": ["<plain English for line 1>", "<plain English for line 2>", ...], "overall_interpretation": "<1-3 sentences: what the whole letter means in plain English>"}
   """
 
   @doc """
@@ -74,7 +88,7 @@ defmodule CreatureCrossing.RansomNotes.Judge do
           %{role: "system", content: @system_prompt},
           %{role: "user", content: "Prompt: #{prompt}\n\nLetter:\n#{letter_text}"}
         ],
-        max_tokens: 256,
+        max_tokens: 512,
         temperature: 0.7
       }
 
@@ -103,13 +117,20 @@ defmodule CreatureCrossing.RansomNotes.Judge do
     |> String.trim()
     |> Jason.decode()
     |> case do
-      {:ok, %{"relevance" => r, "creativity" => c, "commentary" => commentary}}
+      {:ok,
+       %{
+         "relevance" => r,
+         "creativity" => c,
+         "commentary" => commentary
+       } = parsed}
       when is_number(r) and is_number(c) ->
         {:ok,
          %{
            relevance: min(round(r), 10),
            creativity: min(round(c), 10),
-           commentary: commentary
+           commentary: commentary,
+           line_interpretations: Map.get(parsed, "line_interpretations", []),
+           overall_interpretation: Map.get(parsed, "overall_interpretation", "")
          }}
 
       {:ok, _other} ->

--- a/lib/creature_crossing/ransom_notes/judge.ex
+++ b/lib/creature_crossing/ransom_notes/judge.ex
@@ -1,0 +1,130 @@
+defmodule CreatureCrossing.RansomNotes.Judge do
+  @moduledoc """
+  Judges Ransom Notes letters using the Mercury API (Inception Labs).
+  Scores on relevance and creativity with AC-themed commentary.
+  """
+
+  @api_url "https://api.inceptionlabs.ai/v1/chat/completions"
+  @model "mercury-coder-small"
+
+  @system_prompt """
+  You are Isabelle from Animal Crossing, judging letters written by island residents.
+  You have deep knowledge of the Animal Crossing universe across all games — characters,
+  villagers, items, events, community culture, memes, and in-jokes.
+
+  You understand that:
+  - Tom Nook is often jokingly called a loan shark by the community
+  - "Sea bass" catches are a running disappointment meme ("It's at least a C+!")
+  - Tarantula/scorpion island farming is a beloved money-making strategy
+  - Time traveling (changing the system clock) is a divisive community topic
+  - Villager hunting with Nook Miles Tickets is a rite of passage
+  - Marshal, Raymond, and Ankha are some of the most sought-after "dreamie" villagers
+  - Zipper T. Bunny is widely suspected to be a costumed character and is found unsettling
+  - Blathers is terrified of bugs despite running the museum
+  - K.K. Slider is the beloved musician who plays every Saturday
+  - Redd sells both genuine and forged artwork
+  - The Happy Home Academy judges your home decor
+  - Brewster runs The Roost cafe and is very particular about coffee
+  - "Nook Inc" is treated as a corporate overlord meme
+  - Star trees were a glitch in early AC games that players want back
+  - Mean/rude villager dialogue from older games is nostalgically missed
+  - Amiibo Festival is widely considered the worst AC game
+
+  You also understand the game mechanic: players are building responses from RANDOM word tiles,
+  so grammar will be imperfect. Judge the intent and creativity, not the grammar. Broken sentences
+  that cleverly convey meaning should score HIGHER on creativity than grammatically perfect but
+  boring responses.
+
+  Lateral thinking and indirect references are CREATIVE and should be rewarded. For example,
+  "bug fright man" referring to Blathers is clever. "debt raccoon" for Tom Nook is creative.
+
+  Rate each letter on two dimensions:
+  - Relevance (0-10): How well does the letter address the given prompt? Does it stay on topic?
+  - Creativity (0-10): How creative, funny, surprising, or clever is the letter? Reward unusual
+    word combinations, humor, lateral references, and personality.
+
+  Respond ONLY with valid JSON in this exact format, no other text:
+  {"relevance": <0-10>, "creativity": <0-10>, "commentary": "<1-2 sentences of feedback in Isabelle's cheerful voice>"}
+  """
+
+  @doc """
+  Judges a letter asynchronously. Sends the result to the calling process
+  as {:judge_result, {:ok, result}} or {:judge_result, {:error, reason}}.
+  """
+  def judge_async(prompt, letter_text, reply_to \\ self()) do
+    Task.start(fn ->
+      result = judge(prompt, letter_text)
+      send(reply_to, {:judge_result, result})
+    end)
+  end
+
+  @doc """
+  Judges a letter synchronously.
+  Returns {:ok, %{relevance: int, creativity: int, commentary: string}} or {:error, reason}.
+  """
+  def judge(prompt, letter_text) do
+    api_key = get_api_key()
+
+    if is_nil(api_key) or api_key == "" do
+      {:error, "MERCURY_API_KEY not set. Add it to your .env file."}
+    else
+      body = %{
+        model: @model,
+        messages: [
+          %{role: "system", content: @system_prompt},
+          %{role: "user", content: "Prompt: #{prompt}\n\nLetter:\n#{letter_text}"}
+        ],
+        max_tokens: 256,
+        temperature: 0.7
+      }
+
+      case Req.post(@api_url,
+             json: body,
+             headers: [
+               {"authorization", "Bearer #{api_key}"},
+               {"content-type", "application/json"}
+             ],
+             receive_timeout: 15_000
+           ) do
+        {:ok, %{status: 200, body: resp}} ->
+          parse_response(resp)
+
+        {:ok, %{status: status, body: body}} ->
+          {:error, "Mercury API returned status #{status}: #{inspect(body)}"}
+
+        {:error, reason} ->
+          {:error, "Mercury API request failed: #{inspect(reason)}"}
+      end
+    end
+  end
+
+  defp parse_response(%{"choices" => [%{"message" => %{"content" => content}} | _]}) do
+    content
+    |> String.trim()
+    |> Jason.decode()
+    |> case do
+      {:ok, %{"relevance" => r, "creativity" => c, "commentary" => commentary}}
+      when is_number(r) and is_number(c) ->
+        {:ok,
+         %{
+           relevance: min(round(r), 10),
+           creativity: min(round(c), 10),
+           commentary: commentary
+         }}
+
+      {:ok, _other} ->
+        {:error, "Unexpected JSON structure from judge"}
+
+      {:error, _} ->
+        {:error, "Failed to parse judge response as JSON"}
+    end
+  end
+
+  defp parse_response(other) do
+    {:error, "Unexpected Mercury API response format: #{inspect(other)}"}
+  end
+
+  defp get_api_key do
+    System.get_env("MERCURY_API_KEY")
+  end
+end

--- a/lib/creature_crossing_web/live/ransom_notes_live.ex
+++ b/lib/creature_crossing_web/live/ransom_notes_live.ex
@@ -13,6 +13,7 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
   use CreatureCrossingWeb, :live_view
 
   alias CreatureCrossing.RansomNotes.WordPool
+  alias CreatureCrossing.RansomNotes.Judge
 
   @rounds_per_game 10
   @tiles_per_round 50
@@ -412,10 +413,8 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
     if String.trim(letter_text) == "" do
       {:noreply, socket}
     else
-      # TODO: Wire up Mercury API judge in PR 5
-      # For now, transition to judging and immediately return placeholder scores
       socket = assign(socket, phase: :judging)
-      send(self(), {:judge_result, {:ok, placeholder_score()}})
+      Judge.judge_async(socket.assigns.prompt, letter_text)
       {:noreply, socket}
     end
   end
@@ -504,10 +503,6 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
 
   defp all_lines_empty?(placed_tiles) do
     Enum.all?(placed_tiles, fn {_line, tiles} -> tiles == [] end)
-  end
-
-  defp placeholder_score do
-    %{relevance: Enum.random(3..8), creativity: Enum.random(3..8), commentary: "This is a placeholder score. The Mercury judge will be wired up soon!"}
   end
 
   defp rank_title(score, max) do

--- a/lib/creature_crossing_web/live/ransom_notes_live.ex
+++ b/lib/creature_crossing_web/live/ransom_notes_live.ex
@@ -108,6 +108,11 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
   defp render_playing(assigns) do
     ~H"""
     <div id="ransom-notes-game" phx-hook=".RansomNotesDragDrop" class="flex flex-col items-center gap-4 w-full max-w-3xl">
+      <%!-- Error alert --%>
+      <div :if={@judging_error} class="alert alert-error max-w-lg">
+        <span>Judging failed: {@judging_error}</span>
+      </div>
+
       <%!-- Prompt --%>
       <div class="text-center">
         <p class="text-sm opacity-60 mb-1">Round {@round} of {@max_rounds}</p>

--- a/lib/creature_crossing_web/live/ransom_notes_live.ex
+++ b/lib/creature_crossing_web/live/ransom_notes_live.ex
@@ -55,6 +55,7 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
             available_tiles={@available_tiles}
             placed_tiles={@placed_tiles}
             selected_tile={@selected_tile}
+            judging_error={@judging_error}
           />
         <% :judging -> %>
           <.render_judging prompt={@prompt} round={@round} />

--- a/lib/creature_crossing_web/live/ransom_notes_live.ex
+++ b/lib/creature_crossing_web/live/ransom_notes_live.ex
@@ -285,6 +285,20 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
         "{@latest.commentary}"
       </div>
 
+      <%!-- Isabelle's interpretation --%>
+      <div :if={@latest.line_interpretations != [] or @latest.overall_interpretation != ""}
+           class="bg-base-100 border border-base-300 rounded-xl p-4 mb-4 text-left text-sm">
+        <p class="font-bold mb-2 text-center">How Isabelle read your letter:</p>
+        <div :if={@latest.line_interpretations != []} class="space-y-1 mb-3">
+          <p :for={{interp, idx} <- Enum.with_index(@latest.line_interpretations, 1)}>
+            <span class="font-semibold opacity-60">Line {idx}:</span> {interp}
+          </p>
+        </div>
+        <div :if={@latest.overall_interpretation != ""} class="border-t border-base-300 pt-2">
+          <p><span class="font-semibold">Overall:</span> {@latest.overall_interpretation}</p>
+        </div>
+      </div>
+
       <p class="text-lg mb-6">
         Running total: <strong>{@total_score}</strong> / {@round * 20}
       </p>

--- a/lib/creature_crossing_web/live/ransom_notes_live.ex
+++ b/lib/creature_crossing_web/live/ransom_notes_live.ex
@@ -34,7 +34,8 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
         selected_tile: nil,
         scores: [],
         total_score: 0,
-        judging_error: nil
+        judging_error: nil,
+        last_letter_lines: []
       )
 
     {:ok, socket}
@@ -65,6 +66,7 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
             max_rounds={@max_rounds}
             scores={@scores}
             total_score={@total_score}
+            last_letter_lines={@last_letter_lines}
           />
         <% :game_over -> %>
           <.render_game_over scores={@scores} total_score={@total_score} max_rounds={@max_rounds} />
@@ -289,12 +291,17 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
       <div :if={@latest.line_interpretations != [] or @latest.overall_interpretation != ""}
            class="bg-base-100 border border-base-300 rounded-xl p-4 mb-4 text-left text-sm">
         <p class="font-bold mb-2 text-center">How Isabelle read your letter:</p>
-        <div :if={@latest.line_interpretations != []} class="space-y-1 mb-3">
-          <p :for={{interp, idx} <- Enum.with_index(@latest.line_interpretations, 1)}>
-            <span class="font-semibold opacity-60">Line {idx}:</span> {interp}
-          </p>
+        <div :if={@latest.line_interpretations != []} class="space-y-3 mb-3">
+          <div :for={{interp, idx} <- Enum.with_index(@latest.line_interpretations)}>
+            <p class="font-mono bg-amber-50 text-amber-950 border border-amber-200 rounded px-2 py-1 mb-1">
+              {Enum.at(@last_letter_lines, idx, "")}
+            </p>
+            <p class="opacity-70 pl-2">
+              → {interp}
+            </p>
+          </div>
         </div>
-        <div :if={@latest.overall_interpretation != ""} class="border-t border-base-300 pt-2">
+        <div :if={@latest.overall_interpretation != ""} class="border-t border-base-300 pt-2 mt-2">
           <p><span class="font-semibold">Overall:</span> {@latest.overall_interpretation}</p>
         </div>
       </div>
@@ -428,13 +435,13 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
   end
 
   def handle_event("submit_letter", _params, socket) do
-    letter_text = build_letter_text(socket.assigns.placed_tiles)
+    letter_lines = build_letter_lines(socket.assigns.placed_tiles)
 
-    if String.trim(letter_text) == "" do
+    if letter_lines == [] do
       {:noreply, socket}
     else
-      socket = assign(socket, phase: :judging)
-      Judge.judge_async(socket.assigns.prompt, letter_text)
+      socket = assign(socket, phase: :judging, last_letter_lines: letter_lines)
+      Judge.judge_async(socket.assigns.prompt, Enum.join(letter_lines, "\n"))
       {:noreply, socket}
     end
   end
@@ -506,7 +513,7 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
     end)
   end
 
-  defp build_letter_text(placed_tiles) do
+  defp build_letter_lines(placed_tiles) do
     0..6
     |> Enum.map(fn line ->
       placed_tiles
@@ -514,7 +521,6 @@ defmodule CreatureCrossingWeb.RansomNotesLive do
       |> Enum.map_join(" ", & &1.word)
     end)
     |> Enum.reject(&(&1 == ""))
-    |> Enum.join("\n")
   end
 
   defp tile_rotation(id) do


### PR DESCRIPTION
## Summary
- Adds `CreatureCrossing.RansomNotes.Judge` module with Mercury API integration
- Rich system prompt: Isabelle persona with AC community culture knowledge (memes, lateral references, villager hunting, Tom Nook loan shark jokes, etc.)
- Rewards creative/lateral word combinations over grammatically perfect but boring responses
- Async judging via Task — LiveView shows loading spinner during API call
- Replaces placeholder scoring
- Requires `MERCURY_API_KEY` env var (source `.env` before starting server)

## Test plan
- [x] Compiles cleanly
- [x] Server starts with API key loaded
- [x] Submit a letter and receive real scores + Isabelle commentary
- [x] Verify scores are 0-10 range
- [x] Test with empty/minimal letters
- [ ] Verify error handling when API key is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)